### PR TITLE
feat: get total ramme count

### DIFF
--- a/src/core/repository.ts
+++ b/src/core/repository.ts
@@ -7,6 +7,12 @@ export type Repository<T> = {
   get: (id: string) => Promise<Event<T>[]>
   getByWeek: (week: number) => Promise<Event<T>[]>
   getByCommitter: (committer: string, week?: number) => Promise<Event<T>[]>
+  getTotal: () => Promise<Summary<T>[]>
+}
+
+export type Summary<T> = {
+  committer: string
+  count: number
 }
 
 export type Event<T> = {
@@ -27,6 +33,7 @@ export const createRepository = <T>(dbConn: Pool) => {
     get: getFn(dbConn),
     getByWeek: getByWeekFn(dbConn),
     getByCommitter: getByCommitterFn(dbConn),
+    getTotal: getTotalFn(dbConn),
   } as Repository<T>
 }
 
@@ -85,4 +92,12 @@ const getByCommitterFn = <T>(dbConn: Pool) => async (
   }
 
   return res.rows as Event<T>[]
+}
+
+const getTotalFn = <T>(dbConn: Pool) => async () => {
+  const res = await dbConn.query(
+    `SELECT committer, COUNT(*) FROM events GROUP BY committer`,
+  )
+
+  return res.rows as Summary<T>[]
 }

--- a/src/core/test.fixture.ts
+++ b/src/core/test.fixture.ts
@@ -5,6 +5,7 @@ const mockRepo = {
   get: jest.fn(),
   getByWeek: jest.fn(),
   getByCommitter: jest.fn(),
+  getTotal: jest.fn(),
 }
 
 export const mockRepoFactory = <T>(p?: Partial<Repository<T>>) => ({

--- a/src/ramme/archiveRammeHandler.ts
+++ b/src/ramme/archiveRammeHandler.ts
@@ -1,6 +1,5 @@
-import { Repository, Event } from '../core'
+import { Repository } from '../core'
 import { Ramme, RammeEvents } from '.'
-import { logger } from '../utils/logger'
 import { Request, Response } from 'express'
 import { parseIdFromCommand } from './parseIdFromCommand'
 

--- a/src/ramme/getTotalHandler.ts
+++ b/src/ramme/getTotalHandler.ts
@@ -1,0 +1,23 @@
+import { Repository, Summary } from '../core'
+import { Ramme } from '.'
+import { Response } from 'express'
+
+export const getTotalHandler = async (
+  res: Response,
+  repository: Repository<Ramme>,
+) => {
+  const total = await repository.getTotal()
+  const formattedTotal = formatTotal(total)
+
+  res.send({
+    response_type: 'in_channel',
+    text: formattedTotal,
+  })
+}
+
+const formatTotal = (total: Summary<Ramme>[]) => {
+  const totalStrings = total.map(row => {
+    return `${row.committer}: ${row.count}`
+  })
+  return totalStrings.join('\n')
+}

--- a/src/ramme/helpRammeHandler.ts
+++ b/src/ramme/helpRammeHandler.ts
@@ -18,7 +18,9 @@ export const helpRammeHandler = async (
     -'/ramme edit <id> <aktivitet>' för att uppdatera aktivitet med id: <id> till aktivitet: <aktivitet>
 
     -'/ramme arkivera <id>' för att arkivera pass med id: <id>
-    `
+
+    -'/ramme total' för att se totalt antal pass`
+
     res.send({
       response_type: 'in_channel',
       text: response,

--- a/src/ramme/index.ts
+++ b/src/ramme/index.ts
@@ -4,6 +4,7 @@ export * from './archiveRammeHandler'
 export * from './getByWeekHandler'
 export * from './commandParser'
 export * from './reduceRamme'
+export * from './getTotalHandler'
 
 export type Ramme = {
   activity: string

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import {
   addRammeHandler,
   commandParser,
   archiveRammeHandler,
+  getTotalHandler,
 } from './ramme'
 import { getByWeekHandler } from './ramme/getByWeekHandler'
 import express from 'express'
@@ -56,6 +57,10 @@ const start = async () => {
       }
       case 'arkivera': {
         archiveRammeHandler(req, res, rammeRepo)
+        break
+      }
+      case 'total': {
+        getTotalHandler(res, rammeRepo)
         break
       }
       case 'help':


### PR DESCRIPTION
`/ramme total` is now showing total count of activities aka leaderboard (non-sorted atm)